### PR TITLE
Version 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+## Changelog
+
+0.1.0
+-----
+* First initial beta release.
+
+0.2.0
+-----
+* Added configuration option `json_document_type_schema` which gives ability to optionally enable and enforce a JSON schema validation for JSON format messages.
+* Added option `enable_syslog_format_only`, which gives the ability to run process in a mode that only accepts syslog type messages.  This could be used as a logging replacement for processes that log to local syslog address.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Ensure that this folder is at the following location:
 ### Requirements
 
 * [Golang](https://golang.org/dl/) 1.7
+* github.com/pquerna/ffjson/ffjson
+* github.com/xeipuuv/gojsonschema
+
 
 
 ### Log Structure
@@ -37,6 +40,8 @@ json:my_application:{"message":"This is a test JSON message", "application":"my\
 ```
 
 *Please note the current date/time is automatically added to each log entry.*
+
+### Configuration Options
 
 ### Sample Clients
 

--- a/README.md
+++ b/README.md
@@ -40,20 +40,24 @@ udplogbeat:
   port: 5001
   max_message_size: 2048
   enable_json_validation: true
-  # JSON schemas can be automatically generated from an object here: http://jsonschema.net/
   json_document_type_schema: 
     email_contact: "/etc/udplogbeat/app1_schema.json"
     stock_item: "/etc/udplogbeat/app2_schema.json"
 ```
 
+JSON schemas can be automatically generated from an object here: http://jsonschema.net/.  You can also view the included sample schemas `app1_schema.json` and `app2_schema.json` as examples.
+
 #### Considerations
 
-Keep in mind if you intend on using this as a drop-in replacement to logging to a file with Rsyslog, this method will not persist your data to a file on disk.
-It could be technically possible to loose some data, therefore if you need 100% guarantee each message will be delivered at least once, this may not be the best solution for you.
+If you intend on using this as a drop-in replacement to logging with Rsyslog, this method will not persist your data to a file on disk.  
+If udplogbeat is down for any given reason, messages sent to the configured UDP port will never be processed or sent to your ELK cluster.
+If you need 100% guarantee each message will be delivered at least once, this may not be the best solution for you.  
+If some potential loss of log events is acceptable for you, than this may be a reasonable solution for you.
+
 
 ### Log Structure
 
-In order for the udplogbeat application to accept events, they must be structured in the following format:
+In order for the udplogbeat application to accept events, when not in syslog format only mode (*enable_syslog_format_only: false*), they must be structured in the following format:
 
 **[FORMAT]:[ES_TYPE]:[EVENT_DATA]**
 
@@ -108,6 +112,11 @@ in the same directory with the name udplogbeat.
 make
 ```
 
+Or to build the zipped binaries for OSX, Windows and Linux:
+
+./build_os_binaries.sh "[VERSION_NUMBER]"
+
+These will be placed in the `bin/` directory.
 
 ### Run
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,41 @@ Ensure that this folder is at the following location:
 * github.com/pquerna/ffjson/ffjson
 * github.com/xeipuuv/gojsonschema
 
+### Configuration Options
 
+- `udplogbeat.port` : The UDP port on which the process will listen (Default = 5000)
+- `udplogbeat.max_message_size` : The maximum accepted message size (Default = 1024)
+- `udplogbeat.enable_syslog_format_only` : Boolean value indicating if only syslog messages should be accepted. (Default = false)
+- `udplogbeat.enable_json_validation` : Boolean value indicating if JSON schema validation should be applied for `json` format messages (Default = false)
+- `udplogbeat.publish_failed_json_invalid` : Boolean value indicating if JSON objects should be sent serialized in the event of a failed validation.  This will add the `_udplogbeat_jspf` tag. (Default = false)
+- `udplogbeat.json_document_type_schema` :  A hash consisting of the Elasticsearch type as the key, and the absolute local schema file path as the value.
+
+### Configuration Example
+
+Sample configuration for a syslog replacement
+```
+udplogbeat:
+  port: 5000
+  max_message_size: 4096
+  enable_syslog_format_only: false
+```
+
+Sample configuration that enforces schemas for JSON format events
+```
+udplogbeat:
+  port: 5001
+  max_message_size: 2048
+  enable_json_validation: true
+  # JSON schemas can be automatically generated from an object here: http://jsonschema.net/
+  json_document_type_schema: 
+    email_contact: "/etc/udplogbeat/app1_schema.json"
+    stock_item: "/etc/udplogbeat/app2_schema.json"
+```
+
+#### Considerations
+
+Keep in mind if you intend on using this as a drop-in replacement to logging to a file with Rsyslog, this method will not persist your data to a file on disk.
+It could be technically possible to loose some data, therefore if you need 100% guarantee each message will be delivered at least once, this may not be the best solution for you.
 
 ### Log Structure
 
@@ -40,8 +74,6 @@ json:my_application:{"message":"This is a test JSON message", "application":"my\
 ```
 
 *Please note the current date/time is automatically added to each log entry.*
-
-### Configuration Options
 
 ### Sample Clients
 

--- a/app1_schema.json
+++ b/app1_schema.json
@@ -16,5 +16,6 @@
         }
       }
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/app1_schema.json
+++ b/app1_schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "email": {
+      "type": "string"
+    },
+    "name": {
+      "type": "object",
+      "properties": {
+        "first": {
+          "type": "string"
+        },
+        "last": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/app2_schema.json
+++ b/app2_schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "item": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "price": {
+      "type": "integer"
+    },
+    "stock_count": {
+      "type": "integer"
+    }
+  }
+}

--- a/app2_schema.json
+++ b/app2_schema.json
@@ -19,5 +19,6 @@
     "stock_count": {
       "type": "integer"
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/build_os_binaries.sh
+++ b/build_os_binaries.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+GOOS=linux GOARCH=amd64 go build -ldflags "-s -w" -o bin/udplogbeat-$1-linux-amd64
+zip bin/udplogbeat-$1-linux-amd64.zip bin/udplogbeat-$1-linux-amd64
+GOOS=darwin GOARCH=amd64 go build -ldflags "-s -w" -o bin/udplogbeat-$1-darwin-amd64
+zip bin/udplogbeat-$1-darwin-amd64.zip bin/udplogbeat-$1-darwin-amd64
+GOOS=windows GOARCH=amd64 go build -ldflags "-s -w" -o bin/udplogbeat-$1-windows-amd64
+zip bin/udplogbeat-$1-windows-amd64.zip bin/udplogbeat-$1-windows-amd64

--- a/config/config.go
+++ b/config/config.go
@@ -6,14 +6,17 @@ package config
 import "time"
 
 type Config struct {
-	Period         time.Duration `config:"period"`
-	Port           int           `config:"port"`
-	MaxMessageSize int           `config:"max_message_size"`
-	Addr           string
+	Period                 time.Duration `config:"period"`
+	Port                   int           `config:"port"`
+	MaxMessageSize         int           `config:"max_message_size"`
+	Addr                   string
+	EnableJsonValidation   bool              `config:"enable_json_validation"`
+	JsonDocumentTypeSchema map[string]string `config:"json_document_type_schema"`
 }
 
 var DefaultConfig = Config{
-	Period:         1 * time.Second,
-	Port:           5000,
-	MaxMessageSize: 1024,
+	Period:               1 * time.Second,
+	Port:                 5000,
+	MaxMessageSize:       1024,
+	EnableJsonValidation: false,
 }

--- a/config/config.go
+++ b/config/config.go
@@ -6,17 +6,23 @@ package config
 import "time"
 
 type Config struct {
-	Period                 time.Duration `config:"period"`
-	Port                   int           `config:"port"`
-	MaxMessageSize         int           `config:"max_message_size"`
-	Addr                   string
-	EnableJsonValidation   bool              `config:"enable_json_validation"`
-	JsonDocumentTypeSchema map[string]string `config:"json_document_type_schema"`
+	Period                            time.Duration `config:"period"`
+	Port                              int           `config:"port"`
+	MaxMessageSize                    int           `config:"max_message_size"`
+	Addr                              string
+	EnableSyslogFormatOnly            bool              `config:"enable_syslog_format_only"`
+	EnableJsonValidation              bool              `config:"enable_json_validation"`
+	PublishFailedJsonSchemaValidation bool              `config:publish_failed_json_schema_validation`
+	PublishFailedJsonInvalid          bool              `config:publish_failed_json_invalid`
+	JsonDocumentTypeSchema            map[string]string `config:"json_document_type_schema"`
 }
 
 var DefaultConfig = Config{
-	Period:               1 * time.Second,
-	Port:                 5000,
-	MaxMessageSize:       1024,
-	EnableJsonValidation: false,
+	Period:                            1 * time.Second,
+	Port:                              5000,
+	MaxMessageSize:                    1024,
+	EnableJsonValidation:              false,
+	PublishFailedJsonSchemaValidation: false,
+	PublishFailedJsonInvalid:          false,
+	EnableSyslogFormatOnly:            false,
 }

--- a/udplogbeat.template-es2x.json
+++ b/udplogbeat.template-es2x.json
@@ -18,7 +18,7 @@
               "type": "string"
             },
             "match_mapping_type": "string",
-            "path_match": "fields.*"
+            "match": "*"
           }
         }
       ],

--- a/udplogbeat.template.json
+++ b/udplogbeat.template.json
@@ -15,7 +15,7 @@
               "type": "keyword"
             },
             "match_mapping_type": "string",
-            "path_match": "fields.*"
+            "match": "*"
           }
         }
       ],

--- a/udploglib/utils.go
+++ b/udploglib/utils.go
@@ -1,8 +1,10 @@
 package udploglib
 
 import (
+	//"errors"
 	"fmt"
 	"strings"
+	//"github.com/xeipuuv/gojsonschema"
 )
 
 // GetLogItem returns the log entry format, elasticsearch type, message and error (if any)

--- a/udploglib/utils.go
+++ b/udploglib/utils.go
@@ -8,21 +8,21 @@ import (
 )
 
 // GetLogItem returns the log entry format, elasticsearch type, message and error (if any)
-func GetLogItem(buf []byte) (string, string, string, error) {
+func GetLogItem(buf []byte) ([]string, error) {
 
 	parts := strings.SplitN(string(buf), ":", 3)
 	if len(parts) != 3 {
-		return "", "", "", fmt.Errorf("Invalid log item")
+		return []string{"", "", ""}, fmt.Errorf("Invalid log item")
 	}
 	if parts[0] != "json" && parts[0] != "plain" {
-		return "", "", "", fmt.Errorf("Log format %s is invalid", parts[0])
+		return []string{"", "", ""}, fmt.Errorf("Log format %s is invalid", parts[0])
 	}
 	if parts[1] == "" {
-		return "", "", "", fmt.Errorf("A log type must be specified")
+		return []string{"", "", ""}, fmt.Errorf("A log type must be specified")
 	}
 	if parts[2] == "" {
-		return "", "", "", fmt.Errorf("Log data is empty")
+		return []string{"", "", ""}, fmt.Errorf("Log data is empty")
 	}
 
-	return strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]), strings.TrimSpace(parts[2]), nil
+	return []string{strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]), strings.TrimSpace(parts[2])}, nil
 }


### PR DESCRIPTION

* Added configuration option `json_document_type_schema` which gives ability to optionally enable and enforce a JSON schema validation for JSON format messages ([Issue #2](https://github.com/hartfordfive/udplogbeat/issues/2)).
* Added option `enable_syslog_format_only`, which gives the ability to run process in a mode that only accepts syslog type messages.  This could be used as a logging replacement for processes that log to local syslog address.